### PR TITLE
agregue un scroll-y en el contenedor de herramientas 

### DIFF
--- a/src/Components/styles/WorkElement.css
+++ b/src/Components/styles/WorkElement.css
@@ -8,6 +8,7 @@
 .tools-container {
   max-height: 0;
   overflow: hidden;
+  overflow-y: auto;
   transition: max-height 0.4s ease;
 }
   


### PR DESCRIPTION
No se podian ver todas las herramientas de cada obra, quedaban ocultas