### PR TITLE
Solucion de algunos problemas y algunas prevenciones

### DIFF
--- a/src/Components/FormAddTool.js
+++ b/src/Components/FormAddTool.js
@@ -27,7 +27,7 @@ export default function FormAddTool({showForm}){
         setFormData(data=>{
             return {
                 ...data,
-                [name]: value
+                [name]: name === "nombre" ? value.trim() : value
             }
         })
         return

--- a/src/Components/FormAddTool.js
+++ b/src/Components/FormAddTool.js
@@ -1,6 +1,7 @@
 import '../Routes/styles/Tools.css'
 import { useState } from 'react';
 import useStore from '../services/useStore';
+import LoaderToData from './LoaderToData';
 const apiBaseUrl = process.env.REACT_APP_API_BASE_URL
 
 export default function FormAddTool({showForm}){
@@ -16,6 +17,7 @@ export default function FormAddTool({showForm}){
     const [mensaje, setMensaje] = useState('');
     const addToolInStore = useStore((state) => state.agregarHerramienta);
     const {obras, cargarDatosDesdeAPI} = useStore();
+    const [loaded, setLoaded] = useState(false)
 
     const handleFormData = (e) => {
         e.preventDefault();
@@ -39,7 +41,7 @@ export default function FormAddTool({showForm}){
           e.target.disabled = false
           return setMensaje('Debe registrar el estado de la herramienta');
         } 
-
+        setLoaded(true)
         const toolFormated = {
             ...formData,
             cantidad_total: Number(parseInt(formData.cantidad_total)),
@@ -54,7 +56,6 @@ export default function FormAddTool({showForm}){
               },
               body: JSON.stringify(toolFormated),
             });
-            console.log(res);
             
             if (res.ok) {
               const {message, data} = await res.json(); // respuesta con la herramienta creada
@@ -64,6 +65,7 @@ export default function FormAddTool({showForm}){
               showForm(false);
               await cargarDatosDesdeAPI()
             } else {
+              setLoaded(false)
               setMensaje('Error al agregar herramienta');
             }
           } catch (err) {
@@ -103,8 +105,11 @@ export default function FormAddTool({showForm}){
             <p style={{color:'#2a44a8', textAlign: 'center', fontSize: "14px"}}>La ubicacion de la herramienta por defecto es Galpon</p>
             
             <input type="text" className="input-observacion" name='observacion' defaultValue={formData.observacion} placeholder='observaciones'/>
-
-            <button type="submit" name='asdfs' onClick={submitNewTool} className="submit-btn">Guardar</button>
+            {
+              !loaded &&
+              <button type="submit" name='asdfs' onClick={submitNewTool} className="submit-btn">Guardar</button>
+            }
+            {loaded && <LoaderToData/>}
             
             {mensaje && <p style={{color: 'red', fontSize: '16px'}}>{mensaje}</p>}
         </form>

--- a/src/Components/FormAddWork.js
+++ b/src/Components/FormAddWork.js
@@ -19,7 +19,7 @@ export function FormAddWork({showForm}){
         setWork(work=>{
             return{
                 ...work,
-                [name]: value
+                [name]: value.trim()
             }
         })
     };

--- a/src/Components/ModalConfirmDeletWork.js
+++ b/src/Components/ModalConfirmDeletWork.js
@@ -1,9 +1,11 @@
 import "./styles/ModalDelWork.css"
 import { useState } from "react"
+import LoaderToData from "./LoaderToData"
 
 export default function ModalConfirmDeleteWork({work_name, work_id, closeModal}){
     const [confirmName, setConfirmName] = useState("")
     const [msg, setMsg] = useState("")
+    const [loaded, setLoaded] = useState(false)
 
     const handleChange = (e)=>{
         setMsg("")
@@ -16,7 +18,7 @@ export default function ModalConfirmDeleteWork({work_name, work_id, closeModal})
         console.log(confirmName === work_name);
         
         if(confirmName === work_name){
-            
+            setLoaded(true)
             const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/delete-work`,{
                 method: "DELETE",
                 headers: {
@@ -24,17 +26,13 @@ export default function ModalConfirmDeleteWork({work_name, work_id, closeModal})
                 },
                 body: JSON.stringify({id: work_id})
             })
-        
+            
             if(!res.ok) {
                 setMsg("Error de servidor")  
                 return console.log(res)
             };
-        
-            const data = await res.json()
-            console.log(data);
 
             window.location.reload()
-            return closeModal()
         }else{
             setMsg("No hay coincidencia")
             return
@@ -52,10 +50,14 @@ export default function ModalConfirmDeleteWork({work_name, work_id, closeModal})
                         msg.length > 0 && <p style={{fontSize: "1rem", textAlign: "center", color: "#e35752", fontWeight: '600'}}>{msg}</p>
                     }
 
-                    <input type="text" id="input-confirmDelete"/>
+                    <input type="text" id="input-confirmDelete" autoComplete="off"/>
                     <div className="contain-btnModalDelet">
-                        <button onClick={closeModal} className="btns-del-modal btn-cancel">Cancelar</button>
-                        <button onClick={handleClick} className="btns-del-modal btn-del">Eliminar</button>
+                        {
+                            !loaded ? (<>
+                            <button onClick={closeModal} className="btns-del-modal btn-cancel">Cancelar</button>
+                            <button onClick={handleClick} className="btns-del-modal btn-del">Eliminar</button>
+                            </>) : <LoaderToData />
+                        }
                     </div>
                 </form>
             </div>

--- a/src/Components/MoveTool.js
+++ b/src/Components/MoveTool.js
@@ -83,7 +83,9 @@ export default function MoveTool({nameTool, fromWork, quantityInWork, medida, cl
                 {
                     loaded && <LoaderToData/>
                 }
-                <button className='btnMoveTool_modal'>Mover herramienta</button>
+                {
+                    !loaded && <button className='btnMoveTool_modal'>Mover herramienta</button>
+                }
             </form>
         </div>
     )


### PR DESCRIPTION
Los nombres de herramientas u obras ya no se van a guardar con espacios al final o al principio como lo hacían antes.
Ahora se evita la múltiple inserción de las herramientas por accidente y al presionar el btn de guardar un loader reemplazará el btn.